### PR TITLE
'internal-facing' not an allowed value according to documentation: ht…

### DIFF
--- a/lib/nginx-service.ts
+++ b/lib/nginx-service.ts
@@ -113,7 +113,7 @@ export class NginxService extends cdk8s.Chart {
                 namespace: namespace.name,
                 annotations: {
                     'kubernetes.io/ingress.class': 'alb',
-                    'alb.ingress.kubernetes.io/scheme': 'internal', // Set ALB for K8S Ingress as internal-facing service.
+                    'alb.ingress.kubernetes.io/scheme': 'internal', // Set ALB for K8S Ingress as internet-facing service.
                     'alb.ingress.kubernetes.io/target-type': 'ip',
                 },
                 labels: { app: 'nginx' },


### PR DESCRIPTION
…tps://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/ingress/annotations/

Signed-off-by: floknip <florian.knip@lego.com>

*Issue #:* https://github.com/aws-samples/cdk-eks-fargate/issues/3

*Description of changes:*

Comment suggests the change to a value that does not exist: 'internal-facing' does not exist. Guess it meant to be 'internet-facing'. At least this value is allowed.
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/ingress/annotations/




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
