### PR TITLE
Add missing permission that is needed to provision the ALB

### DIFF
--- a/lib/aws-loadbalancer-controller.ts
+++ b/lib/aws-loadbalancer-controller.ts
@@ -75,6 +75,7 @@ export class AwsLoadBalancerController extends cdk.Construct {
                 'ec2:ModifyInstanceAttribute',
                 'ec2:ModifyNetworkInterfaceAttribute',
                 'ec2:RevokeSecurityGroupIngress',
+                'ec2:DescribeAvailabilityZones'
             ],
             resources: ['*'],
         });


### PR DESCRIPTION
Signed-off-by: floknip <florian.knip@lego.com>

*Issue #:*
https://github.com/aws-samples/cdk-eks-fargate/issues/3

*Description of changes:*
Add missing ec2 iam permission needed to create the ALB

Ref:

- https://githubmemory.com/repo/kubernetes-sigs/aws-load-balancer-controller/issues/2018

